### PR TITLE
feat: add pyright type checking pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,7 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.399
+    hooks:
+      - id: pyright


### PR DESCRIPTION
## Summary

- Added pyright type checking hook to `.pre-commit-config.yaml`
- Uses `RobertCraigie/pyright-python` pre-commit hook (v1.1.399)
- Leverages existing `pyrightconfig.json` configuration

Closes ISW-7