### PR TITLE
Fix RSS feed metadata to use playlist title and image

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -91,9 +91,28 @@ def _is_collect_url(url: str) -> bool:
     query = parse_qs(parsed.query)
     if query.get("type", [""])[0] == "season":
         return True
-    if "favlist" in parsed.path and "series" not in parsed.path:
-        return True
     return False
+
+
+def _ensure_rss_root_namespace(rss_xml: str) -> str:
+    marker = "<rss"
+    start = rss_xml.find(marker)
+    if start < 0:
+        return rss_xml
+
+    end = rss_xml.find(">", start)
+    if end < 0:
+        return rss_xml
+
+    root_open_tag = rss_xml[start:end+1]
+    if 'xmlns:atom="' not in root_open_tag:
+        root_open_tag = root_open_tag[:-1] + ' xmlns:atom="http://www.w3.org/2005/Atom">'
+    if 'xmlns:itunes="' not in root_open_tag:
+        root_open_tag = root_open_tag[:-1] + ' xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">'
+    if ' version="' not in root_open_tag:
+        root_open_tag = root_open_tag[:-1] + ' version="2.0">'
+
+    return rss_xml[:start] + root_open_tag + rss_xml[end+1:]
 
 
 async def _fetch_collect_metadata(client: httpx.AsyncClient, sid: str) -> dict[str, str]:
@@ -160,15 +179,10 @@ async def _get_podcast_metadata(url: str) -> dict[str, str]:
 def _append_channel_and_episode_images(rss_xml: str, episodes: list[dict], image: str | None = None) -> str:
     try:
         root = ET.fromstring(rss_xml.encode("utf-8"))
-        root_tag = root.tag.rsplit("}", 1)[-1]
-        if root_tag == "rss":
-            root.attrib.setdefault("version", "2.0")
-            root.attrib.setdefault("xmlns:atom", "http://www.w3.org/2005/Atom")
-            root.attrib.setdefault("xmlns:itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
         ET.register_namespace("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
         channel = root.find("channel")
         if channel is None:
-            return rss_xml
+            return _ensure_rss_root_namespace(rss_xml)
 
         if image:
             channel_image = channel.find("image")
@@ -193,7 +207,7 @@ def _append_channel_and_episode_images(rss_xml: str, episodes: list[dict], image
             cover_xml = ET.SubElement(item, "{http://www.itunes.com/dtds/podcast-1.0.dtd}image")
             cover_xml.attrib["href"] = cover_image
 
-        return ET.tostring(root, encoding="unicode", xml_declaration=False)
+        return _ensure_rss_root_namespace(ET.tostring(root, encoding="unicode", xml_declaration=False))
     except Exception:
         log.exception("RSS cover image injection failed")
         return rss_xml

--- a/src/main.py
+++ b/src/main.py
@@ -6,16 +6,7 @@ from datetime import datetime, timezone
 from time import monotonic
 from urllib.parse import parse_qs, quote, urlparse
 from pathlib import Path
-<<<<<<< HEAD
 import xml.etree.ElementTree as ET
-=======
-from urllib.parse import quote
-
-# Allow `uv run src/main.py` (script mode) to import project package `src.*`.
-_project_root = Path(__file__).resolve().parents[1]
-if str(_project_root) not in sys.path:
-    sys.path.insert(0, str(_project_root))
->>>>>>> 1fd6bc8 (fix: force UTF-8 RSS output and URL-encode episode file names)
 
 from fastapi import FastAPI
 from fastapi import HTTPException

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,16 @@ from datetime import datetime, timezone
 from time import monotonic
 from urllib.parse import parse_qs, quote, urlparse
 from pathlib import Path
+<<<<<<< HEAD
 import xml.etree.ElementTree as ET
+=======
+from urllib.parse import quote
+
+# Allow `uv run src/main.py` (script mode) to import project package `src.*`.
+_project_root = Path(__file__).resolve().parents[1]
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+>>>>>>> 1fd6bc8 (fix: force UTF-8 RSS output and URL-encode episode file names)
 
 from fastapi import FastAPI
 from fastapi import HTTPException

--- a/src/main.py
+++ b/src/main.py
@@ -281,12 +281,11 @@ async def podcast_rss(name: str, request: Request):
             if published_at.tzinfo is None:
                 published_at = published_at.replace(tzinfo=timezone.utc)
             entry.published(published_at)
-
     rss = feed.rss_str(pretty=True)
     if isinstance(rss, bytes):
         rss = rss.decode("utf-8")
     rss = _append_channel_and_episode_images(rss, episodes, channel_image)
-    return Response(content=rss, media_type="application/rss+xml")
+    return Response(content=rss.encode("utf-8"), media_type="application/rss+xml; charset=utf-8")
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -3,9 +3,10 @@ import mimetypes
 import logging
 import asyncio
 from datetime import datetime, timezone
-from urllib.parse import quote
+from urllib.parse import parse_qs, quote, urlparse
 from pathlib import Path
 import xml.etree.ElementTree as ET
+from typing import Any
 
 from fastapi import FastAPI
 from fastapi import HTTPException
@@ -13,6 +14,8 @@ from fastapi import Request
 from fastapi.responses import FileResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
 from feedgen.feed import FeedGenerator
+from bilix.sites.bilibili import api
+import httpx
 from src.config import check_config_file, get_config
 from src.database import get_episodes, init_database
 from src.downloader import run_downloader
@@ -54,11 +57,123 @@ def podcast_exists(name: str):
     return name in list(map(lambda podcast: podcast["name"], _get_podcasts_from_file()))
 
 
-def _append_episode_images(rss_xml: str, episodes: list[dict]) -> str:
+def _first_non_empty(mapping: dict, keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
+def _extract_sid(url: str) -> str | None:
+    parsed = urlparse(url)
+    path_parts = [part for part in parsed.path.split("/") if part]
+    for idx, part in enumerate(path_parts):
+        if part == "lists" and idx + 1 < len(path_parts):
+            return path_parts[idx + 1]
+
+    qs_sid = parse_qs(parsed.query).get("sid")
+    if qs_sid and qs_sid[0].isdigit():
+        return qs_sid[0]
+
+    return None
+
+
+async def _fetch_collect_metadata(client: httpx.AsyncClient, sid: str) -> dict[str, str]:
+    res = await client.get("https://api.bilibili.com/x/space/fav/season/list", params={"season_id": sid})
+    res.raise_for_status()
+    data = res.json()
+    payload = data.get("data", {})
+    info: dict = payload.get("info", {})
+    medias = payload.get("medias", [])
+    media = medias[0] if medias else {}
+    return {
+        "title": _first_non_empty(info, ("title", "name")),
+        "description": _first_non_empty(info, ("intro", "description")),
+        "image": _first_non_empty(
+            {
+                **media,
+                **info,
+            },
+            ("cover", "cover_url", "pic", "upper",),
+        ),
+    }
+
+
+async def _fetch_list_metadata(client: httpx.AsyncClient, sid: str) -> dict[str, str]:
+    res = await client.get(f"https://api.bilibili.com/x/series/series?series_id={sid}")
+    res.raise_for_status()
+    data = res.json()
+    meta = data.get("data", {}).get("meta", {})
+    return {
+        "title": _first_non_empty(meta, ("name", "title")),
+        "description": _first_non_empty(meta, ("description", "intro")),
+        "image": _first_non_empty(meta, ("cover", "cover_url")),
+    }
+
+
+async def _get_podcast_metadata(url: str) -> dict[str, str]:
+    sid = _extract_sid(url)
+    if not sid:
+        return {}
+
+    async with httpx.AsyncClient(**api.dft_client_settings) as client:
+        try:
+            if "collection" in url:
+                return await _fetch_collect_metadata(client, sid)
+            if "series" in url:
+                return await _fetch_list_metadata(client, sid)
+        except Exception:
+            log.exception("Bilibili 播客元信息获取失败，回退到配置值")
+    return {}
+
+
+def _append_channel_and_episode_images(rss_xml: str, episodes: list[dict], image: str | None = None) -> str:
     if not episodes:
+        if not image:
+            return rss_xml
+        try:
+            ET.register_namespace("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
+            root = ET.fromstring(rss_xml.encode("utf-8"))
+            channel = root.find("channel")
+            if channel is None:
+                return rss_xml
+            if image:
+                image_xml = ET.SubElement(channel, "image")
+                ET.SubElement(image_xml, "url").text = image
+            itunes_xml = ET.SubElement(channel, "{http://www.itunes.com/dtds/podcast-1.0.dtd}image")
+            itunes_xml.attrib["href"] = image
+            return ET.tostring(root, encoding="unicode", xml_declaration=False)
+        except Exception:
+            log.exception("RSS channel image injection failed")
         return rss_xml
+
     try:
         ET.register_namespace("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
+        root = ET.fromstring(rss_xml.encode("utf-8"))
+        channel = root.find("channel")
+        if channel is None:
+            return rss_xml
+
+        if image:
+            channel_image = channel.find("image")
+            if channel_image is None:
+                channel_image = ET.SubElement(channel, "image")
+            ET.SubElement(channel_image, "url").text = image
+
+            itunes_image = channel.find("{http://www.itunes.com/dtds/podcast-1.0.dtd}image")
+            if itunes_image is None:
+                itunes_image = ET.SubElement(
+                    channel,
+                    "{http://www.itunes.com/dtds/podcast-1.0.dtd}image",
+                )
+            itunes_image.attrib["href"] = image
+
+    except Exception:
+        log.exception("RSS channel image injection failed")
+        return rss_xml
+
+    try:
         root = ET.fromstring(rss_xml.encode("utf-8"))
         channel = root.find("channel")
         if channel is None:
@@ -112,12 +227,19 @@ async def podcast_rss(name: str, request: Request):
         raise HTTPException(status_code=404, detail=f"Podcast {name} not found")
 
     config = list(filter(lambda it: it["name"] == name, _get_podcasts_from_file()))[0]
+    podcast_metadata = await _get_podcast_metadata(config["url"])
+    channel_title = podcast_metadata.get("title") or config["name"]
+    channel_description = podcast_metadata.get("description") or f"Podcasts from {name}"
+    channel_image = podcast_metadata.get("image")
+
     episodes = get_episodes(name, limit=config["keep_latest"])
     feed = FeedGenerator()
-    feed.title(f"{name} Podcast")
+    feed.title(channel_title)
     feed.link(href=str(request.url_for("podcast_info", name=name)))
-    feed.description(f"Podcasts from {name}")
+    feed.description(channel_description)
     feed.id(str(request.url_for("podcast_rss", name=name)))
+    if not channel_image and episodes:
+        channel_image = episodes[0].get("cover_image_url") or episodes[0].get("cover")
 
     for episode in episodes:
         encoded_file_name = quote(episode["file_name"])
@@ -143,7 +265,9 @@ async def podcast_rss(name: str, request: Request):
     rss = feed.rss_str(pretty=True)
     if isinstance(rss, bytes):
         rss = rss.decode("utf-8")
-    rss = _append_episode_images(rss, episodes)
+    if channel_image:
+        feed.image(channel_image)
+    rss = _append_channel_and_episode_images(rss, episodes, channel_image)
     return Response(content=rss, media_type="application/rss+xml; charset=utf-8")
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import mimetypes
 import logging
 import asyncio
 from datetime import datetime, timezone
+from time import monotonic
 from urllib.parse import parse_qs, quote, urlparse
 from pathlib import Path
 import xml.etree.ElementTree as ET
@@ -22,6 +23,8 @@ from src.jobs import start_cron_jobs
 
 
 log = logging.getLogger(__name__)
+_PODCAST_METADATA_CACHE: dict[str, tuple[float, dict[str, str]]] = {}
+_PODCAST_METADATA_TTL_SECONDS = 3600.0
 
 
 async def on_startup() -> None:
@@ -78,6 +81,21 @@ def _extract_sid(url: str) -> str | None:
     return None
 
 
+def _metadata_cache_key(url: str, sid: str) -> str:
+    parsed = urlparse(url)
+    return f"{parsed.netloc}|{parsed.path}|{sid}"
+
+
+def _is_collect_url(url: str) -> bool:
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+    if query.get("type", [""])[0] == "season":
+        return True
+    if "favlist" in parsed.path and "series" not in parsed.path:
+        return True
+    return False
+
+
 async def _fetch_collect_metadata(client: httpx.AsyncClient, sid: str) -> dict[str, str]:
     res = await client.get("https://api.bilibili.com/x/space/fav/season/list", params={"season_id": sid})
     res.raise_for_status()
@@ -94,7 +112,7 @@ async def _fetch_collect_metadata(client: httpx.AsyncClient, sid: str) -> dict[s
                 **media,
                 **info,
             },
-            ("cover", "cover_url", "pic", "upper",),
+            ("cover", "cover_url", "pic"),
         ),
     }
 
@@ -116,46 +134,33 @@ async def _get_podcast_metadata(url: str) -> dict[str, str]:
     if not sid:
         return {}
 
+    now = monotonic()
+    cache_key = _metadata_cache_key(url, sid)
+    cache_item = _PODCAST_METADATA_CACHE.get(cache_key)
+    if cache_item is not None:
+        expires_at, cached_data = cache_item
+        if now < expires_at:
+            return cached_data
+
     async with httpx.AsyncClient(**api.dft_client_settings) as client:
         try:
-            if "collection" in url:
-                return await _fetch_collect_metadata(client, sid)
-            if "series" in url:
-                return await _fetch_list_metadata(client, sid)
+            if _is_collect_url(url):
+                data = await _fetch_collect_metadata(client, sid)
+            elif "series" in url:
+                data = await _fetch_list_metadata(client, sid)
+            else:
+                data = {}
+            _PODCAST_METADATA_CACHE[cache_key] = (now + _PODCAST_METADATA_TTL_SECONDS, data)
+            return data
         except Exception:
             log.exception("Bilibili 播客元信息获取失败，回退到配置值")
     return {}
 
 
 def _append_channel_and_episode_images(rss_xml: str, episodes: list[dict], image: str | None = None) -> str:
-    if not episodes:
-        if not image:
-            return rss_xml
-        try:
-            ET.register_namespace("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
-            root = ET.fromstring(rss_xml.encode("utf-8"))
-            channel = root.find("channel")
-            if channel is None:
-                return rss_xml
-            if image:
-                image_xml = channel.find("image")
-                if image_xml is None:
-                    image_xml = ET.SubElement(channel, "image")
-                image_xml_url = image_xml.find("url")
-                if image_xml_url is None:
-                    ET.SubElement(image_xml, "url").text = image
-                else:
-                    image_xml_url.text = image
-            itunes_xml = ET.SubElement(channel, "{http://www.itunes.com/dtds/podcast-1.0.dtd}image")
-            itunes_xml.attrib["href"] = image
-            return ET.tostring(root, encoding="unicode", xml_declaration=False)
-        except Exception:
-            log.exception("RSS channel image injection failed")
-        return rss_xml
-
     try:
-        ET.register_namespace("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
         root = ET.fromstring(rss_xml.encode("utf-8"))
+        ET.register_namespace("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
         channel = root.find("channel")
         if channel is None:
             return rss_xml
@@ -172,21 +177,8 @@ def _append_channel_and_episode_images(rss_xml: str, episodes: list[dict], image
 
             itunes_image = channel.find("{http://www.itunes.com/dtds/podcast-1.0.dtd}image")
             if itunes_image is None:
-                itunes_image = ET.SubElement(
-                    channel,
-                    "{http://www.itunes.com/dtds/podcast-1.0.dtd}image",
-                )
+                itunes_image = ET.SubElement(channel, "{http://www.itunes.com/dtds/podcast-1.0.dtd}image")
             itunes_image.attrib["href"] = image
-
-    except Exception:
-        log.exception("RSS channel image injection failed")
-        return rss_xml
-
-    try:
-        root = ET.fromstring(rss_xml.encode("utf-8"))
-        channel = root.find("channel")
-        if channel is None:
-            return rss_xml
 
         items = channel.findall("item")
         for item, episode in zip(items, episodes):
@@ -274,8 +266,6 @@ async def podcast_rss(name: str, request: Request):
     rss = feed.rss_str(pretty=True)
     if isinstance(rss, bytes):
         rss = rss.decode("utf-8")
-    if channel_image:
-        feed.image(channel_image)
     rss = _append_channel_and_episode_images(rss, episodes, channel_image)
     return Response(content=rss, media_type="application/rss+xml; charset=utf-8")
 

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 from urllib.parse import parse_qs, quote, urlparse
 from pathlib import Path
 import xml.etree.ElementTree as ET
-from typing import Any
 
 from fastapi import FastAPI
 from fastapi import HTTPException
@@ -139,8 +138,14 @@ def _append_channel_and_episode_images(rss_xml: str, episodes: list[dict], image
             if channel is None:
                 return rss_xml
             if image:
-                image_xml = ET.SubElement(channel, "image")
-                ET.SubElement(image_xml, "url").text = image
+                image_xml = channel.find("image")
+                if image_xml is None:
+                    image_xml = ET.SubElement(channel, "image")
+                image_xml_url = image_xml.find("url")
+                if image_xml_url is None:
+                    ET.SubElement(image_xml, "url").text = image
+                else:
+                    image_xml_url.text = image
             itunes_xml = ET.SubElement(channel, "{http://www.itunes.com/dtds/podcast-1.0.dtd}image")
             itunes_xml.attrib["href"] = image
             return ET.tostring(root, encoding="unicode", xml_declaration=False)
@@ -159,7 +164,11 @@ def _append_channel_and_episode_images(rss_xml: str, episodes: list[dict], image
             channel_image = channel.find("image")
             if channel_image is None:
                 channel_image = ET.SubElement(channel, "image")
-            ET.SubElement(channel_image, "url").text = image
+            channel_image_url = channel_image.find("url")
+            if channel_image_url is None:
+                ET.SubElement(channel_image, "url").text = image
+            else:
+                channel_image_url.text = image
 
             itunes_image = channel.find("{http://www.itunes.com/dtds/podcast-1.0.dtd}image")
             if itunes_image is None:

--- a/src/main.py
+++ b/src/main.py
@@ -160,6 +160,11 @@ async def _get_podcast_metadata(url: str) -> dict[str, str]:
 def _append_channel_and_episode_images(rss_xml: str, episodes: list[dict], image: str | None = None) -> str:
     try:
         root = ET.fromstring(rss_xml.encode("utf-8"))
+        root_tag = root.tag.rsplit("}", 1)[-1]
+        if root_tag == "rss":
+            root.attrib.setdefault("version", "2.0")
+            root.attrib.setdefault("xmlns:atom", "http://www.w3.org/2005/Atom")
+            root.attrib.setdefault("xmlns:itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
         ET.register_namespace("itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd")
         channel = root.find("channel")
         if channel is None:
@@ -267,7 +272,7 @@ async def podcast_rss(name: str, request: Request):
     if isinstance(rss, bytes):
         rss = rss.decode("utf-8")
     rss = _append_channel_and_episode_images(rss, episodes, channel_image)
-    return Response(content=rss, media_type="application/rss+xml; charset=utf-8")
+    return Response(content=rss, media_type="application/rss+xml")
 
 
 def main():


### PR DESCRIPTION
### 问题\n- /rss/{name} 标题和描述仍沿用配置名/默认文案\n- 未注入频道级图片\n\n### 改动\n- /rss/{name} 改为优先读取 Bilibili 播放列表元数据（标题/简介/封面）\n- 失败时回退到配置项 name 与默认文案\n- 在 RSS Channel 层补齐标准 image 与 itunes:image（必要时使用首个 episode 封面兜底）\n- 集成失败时记录异常日志并不中断 RSS 生成