### PR TITLE
chore: suppress httpx logs and show download progress

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,5 +4,9 @@ import logging
 logging.basicConfig(
     level="INFO",
 )
+
+for _logger_name in ("httpx", "httpcore"):
+    logging.getLogger(_logger_name).setLevel(logging.WARNING)
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/src/downloader.py
+++ b/src/downloader.py
@@ -107,10 +107,17 @@ async def __run(podcast: Podcast):
     target_dir.mkdir(parents=True, exist_ok=True)
 
     episodes = await __collect_episodes(podcast)
+    episodes_to_download = []
     for episode in episodes:
         exists = get_podcast_by_episode(podcast_name, episode["episode_id"])
-        if exists:
-            continue
+        if not exists:
+            episodes_to_download.append(episode)
+
+    total = len(episodes_to_download)
+    log.info(f"{podcast_name} 需要下载 {total} 条视频")
+
+    for idx, episode in enumerate(episodes_to_download, start=1):
+        log.info(f"{podcast_name} 正在下载第 {idx}/{total} 条：{episode['episode_id']}")
 
         try:
             async with DownloaderBilibili(hierarchy=False) as downloader:


### PR DESCRIPTION
## 变更说明\n\n- 关闭 httpx/httpcore 的 INFO 级别日志，减少下载请求噪音。\n- 下载前先收集待下载清单，输出共需下载条数并在每条下载前打印进度（第 x/N 条）。\n